### PR TITLE
Add LVM as a backing for disks

### DIFF
--- a/bootstrapvz/base/fs/__init__.py
+++ b/bootstrapvz/base/fs/__init__.py
@@ -25,13 +25,15 @@ def load_volume(data, bootloader):
     from bootstrapvz.common.fs.virtualharddisk import VirtualHardDisk
     from bootstrapvz.common.fs.virtualmachinedisk import VirtualMachineDisk
     from bootstrapvz.common.fs.folder import Folder
+    from bootstrapvz.common.fs.logicalvolume import LogicalVolume
     volume_backing = {'raw': LoopbackVolume,
                       's3':  LoopbackVolume,
                       'vdi': VirtualDiskImage,
                       'vhd': VirtualHardDisk,
                       'vmdk': VirtualMachineDisk,
                       'ebs': EBSVolume,
-                      'folder': Folder
+                      'folder': Folder,
+                      'lv': LogicalVolume
                       }.get(data['backing'])
 
     # Instantiate the partition map

--- a/bootstrapvz/base/manifest-schema.yml
+++ b/bootstrapvz/base/manifest-schema.yml
@@ -134,6 +134,7 @@ properties:
     type: object
     properties:
       backing: {type: string}
+      logicalvolume: {type: object}
       partitions:
         type: object
         oneOf:

--- a/bootstrapvz/common/fs/logicalvolume.py
+++ b/bootstrapvz/common/fs/logicalvolume.py
@@ -1,0 +1,30 @@
+from bootstrapvz.base.fs.volume import Volume
+from bootstrapvz.common.tools import log_check_call
+
+
+class LogicalVolume(Volume):
+
+    def create(self, image_path):
+        self.image_path = image_path
+        self.fsm.create(image_path=image_path)
+
+    def _before_create(self, e):
+        lv_size = str(self.size.bytes.get_qty_in('MiB'))
+        vg, lv = e.image_path.split('/')[2:4]
+        log_check_call(['lvcreate', '--size', '{mib}M'.format(mib=lv_size), '--name', lv, vg])
+
+    def _before_attach(self, e):
+        log_check_call(['vgchange', '--activate', 'y', self.image_path.split('/')[2]])
+        mapper_path = '/dev/mapper/' + '-'.join(str(x) for x in self.image_path.split('/')[2:4])
+        [self.loop_device_path] = log_check_call(['losetup', '--show', '--find', '--partscan', mapper_path])
+        self.device_path = self.loop_device_path
+
+    def _before_detach(self, e):
+        log_check_call(['losetup', '--detach', self.loop_device_path])
+        log_check_call(['vgchange', '--activate', 'n', self.image_path.split('/')[2]])
+        del self.loop_device_path
+        self.device_path = None
+
+    def delete(self):
+        log_check_call(['lvremove', '-f', self.image_path])
+        del self.image_path

--- a/bootstrapvz/common/tasks/logicalvolume.py
+++ b/bootstrapvz/common/tasks/logicalvolume.py
@@ -1,0 +1,38 @@
+import bootstrapvz.common.tasks.host as host
+import bootstrapvz.common.tasks.volume as volume
+from bootstrapvz.base import Task
+from bootstrapvz.common import phases
+
+
+class AddRequiredCommands(Task):
+    description = 'Adding commands required for creating and mounting logical volumes'
+    phase = phases.validation
+    successors = [host.CheckExternalCommands]
+
+    @classmethod
+    def run(cls, info):
+        from bootstrapvz.common.fs.logicalvolume import LogicalVolume
+        if type(info.volume) is LogicalVolume:
+            info.host_dependencies['lvcreate'] = 'lvm2'
+            info.host_dependencies['losetup'] = 'mount'
+
+
+class Create(Task):
+    description = 'Creating a Logical volume'
+    phase = phases.volume_creation
+    successors = [volume.Attach]
+
+    @classmethod
+    def run(cls, info):
+        image_path = '/dev/{vg}/{lv}'.format(vg=info.manifest.volume['logicalvolume'].get('vg', None),
+                                             lv=info.manifest.volume['logicalvolume'].get('lv', None))
+        info.volume.create(image_path)
+
+
+class Delete(Task):
+    description = 'Deleting a Logical volume'
+    phase = phases.cleaning
+
+    @classmethod
+    def run(cls, info):
+        info.volume.delete()

--- a/bootstrapvz/providers/kvm/__init__.py
+++ b/bootstrapvz/providers/kvm/__init__.py
@@ -1,6 +1,6 @@
 from bootstrapvz.common import task_groups
 import tasks.packages
-from bootstrapvz.common.tasks import image, loopback, initd, ssh
+from bootstrapvz.common.tasks import image, loopback, initd, ssh, logicalvolume
 
 
 def validate_manifest(data, validator, error):
@@ -12,14 +12,20 @@ def resolve_tasks(taskset, manifest):
     taskset.update(task_groups.get_standard_groups(manifest))
 
     taskset.update([tasks.packages.DefaultPackages,
-                    loopback.AddRequiredCommands,
-                    loopback.Create,
                     initd.InstallInitScripts,
                     ssh.AddOpenSSHPackage,
                     ssh.ShredHostkeys,
                     ssh.AddSSHKeyGeneration,
-                    image.MoveImage,
                     ])
+    if manifest.volume.get('logicalvolume', []):
+        taskset.update([logicalvolume.AddRequiredCommands,
+                        logicalvolume.Create,
+                        ])
+    else:
+        taskset.update([loopback.AddRequiredCommands,
+                        loopback.Create,
+                        image.MoveImage,
+                        ])
 
     if manifest.provider.get('virtio', []):
         from tasks import virtio
@@ -28,3 +34,4 @@ def resolve_tasks(taskset, manifest):
 
 def resolve_rollback_tasks(taskset, manifest, completed, counter_task):
     taskset.update(task_groups.get_standard_rollback_tasks(completed))
+    counter_task(taskset, tasks.Create, tasks.Delete)

--- a/bootstrapvz/providers/kvm/manifest-schema.yml
+++ b/bootstrapvz/providers/kvm/manifest-schema.yml
@@ -32,7 +32,14 @@ properties:
     properties:
       backing:
         type: string
-        enum: [raw]
+        enum: 
+        - raw
+        - lv
+      logicalvolume:
+          type: object
+          properties:
+            lv: {type: string}
+            vg: {type: string}
       partitions:
         type: object
         properties:


### PR DESCRIPTION
Enables the use of Logical Volumes as a disk backing.
This adds a new plugin, lvm, to handle a logical volume and validate the new manifest.