### PR TITLE
Add LVM as a disk backend

### DIFF
--- a/bootstrapvz/base/fs/__init__.py
+++ b/bootstrapvz/base/fs/__init__.py
@@ -25,13 +25,15 @@ def load_volume(data, bootloader):
     from bootstrapvz.common.fs.virtualharddisk import VirtualHardDisk
     from bootstrapvz.common.fs.virtualmachinedisk import VirtualMachineDisk
     from bootstrapvz.common.fs.folder import Folder
+    from bootstrapvz.common.fs.logicalvolume import LogicalVolume
     volume_backing = {'raw': LoopbackVolume,
                       's3':  LoopbackVolume,
                       'vdi': VirtualDiskImage,
                       'vhd': VirtualHardDisk,
                       'vmdk': VirtualMachineDisk,
                       'ebs': EBSVolume,
-                      'folder': Folder
+                      'folder': Folder,
+                      'lvm': LogicalVolume
                       }.get(data['backing'])
 
     # Instantiate the partition map

--- a/bootstrapvz/base/manifest-schema.yml
+++ b/bootstrapvz/base/manifest-schema.yml
@@ -132,6 +132,12 @@ properties:
     additionalProperties: false
   volume:
     type: object
+    oneOf:
+        - $ref: '#/definitions/standardvolume'
+        - $ref: '#/definitions/logicalvolume'
+definitions:
+  standardvolume:
+    type: object
     properties:
       backing: {type: string}
       partitions:
@@ -141,7 +147,20 @@ properties:
           - $ref: '#/definitions/partition_table'
     required: [partitions]
     additionalProperties: false
-definitions:
+  logicalvolume:
+    type: object
+    properties:
+      backing:
+        enum: [lvm]
+      volumegroup : {type: string}
+      logicalvolume: {type: string}
+      partitions:
+        type: object
+        oneOf:
+          - $ref: '#/definitions/no_partitions'
+          - $ref: '#/definitions/partition_table'
+    required: [partitions]
+    additionalProperties: false
   absolute_path:
     type: string
     pattern: ^/[^\0]+$

--- a/bootstrapvz/common/fs/logicalvolume.py
+++ b/bootstrapvz/common/fs/logicalvolume.py
@@ -1,0 +1,38 @@
+from bootstrapvz.base.fs.volume import Volume
+from bootstrapvz.common.tools import log_check_call
+import os
+
+
+class LogicalVolume(Volume):
+
+    def __init__(self, partitionmap):
+        super(LogicalVolume, self).__init__(partitionmap)
+        self.vg = ''
+        self.lv = ''
+
+    def create(self, volumegroup, logicalvolume):
+        self.vg = volumegroup
+        self.lv = logicalvolume
+        image_path = os.path.join(os.sep, 'dev', self.vg, self.lv)
+        self.fsm.create(image_path=image_path)
+
+    def _before_create(self, e):
+        self.image_path = e.image_path
+        lv_size = str(self.size.bytes.get_qty_in('MiB'))
+        log_check_call(['lvcreate', '--size', '{mib}M'.format(mib=lv_size),
+                        '--name', self.lv, self.vg])
+
+    def _before_attach(self, e):
+        log_check_call(['lvchange', '--activate', 'y', self.image_path])
+        [self.loop_device_path] = log_check_call(['losetup', '--show', '--find', '--partscan', self.image_path])
+        self.device_path = self.loop_device_path
+
+    def _before_detach(self, e):
+        log_check_call(['losetup', '--detach', self.loop_device_path])
+        log_check_call(['lvchange', '--activate', 'n', self.image_path])
+        del self.loop_device_path
+        self.device_path = None
+
+    def delete(self):
+        log_check_call(['lvremove', '-f', self.image_path])
+        del self.image_path

--- a/bootstrapvz/common/tasks/logicalvolume.py
+++ b/bootstrapvz/common/tasks/logicalvolume.py
@@ -1,0 +1,37 @@
+import bootstrapvz.common.tasks.host as host
+import bootstrapvz.common.tasks.volume as volume
+from bootstrapvz.base import Task
+from bootstrapvz.common import phases
+
+
+class AddRequiredCommands(Task):
+    description = 'Adding commands required for creating and mounting logical volumes'
+    phase = phases.validation
+    successors = [host.CheckExternalCommands]
+
+    @classmethod
+    def run(cls, info):
+        from bootstrapvz.common.fs.logicalvolume import LogicalVolume
+        if type(info.volume) is LogicalVolume:
+            info.host_dependencies['lvcreate'] = 'lvm2'
+            info.host_dependencies['losetup'] = 'mount'
+
+
+class Create(Task):
+    description = 'Creating a Logical volume'
+    phase = phases.volume_creation
+    successors = [volume.Attach]
+
+    @classmethod
+    def run(cls, info):
+        info.volume.create(volumegroup=info.manifest.volume['volumegroup'],
+                           logicalvolume=info.manifest.volume['logicalvolume'])
+
+
+class Delete(Task):
+    description = 'Deleting a Logical volume'
+    phase = phases.cleaning
+
+    @classmethod
+    def run(cls, info):
+        info.volume.delete()

--- a/bootstrapvz/providers/kvm/README.rst
+++ b/bootstrapvz/providers/kvm/README.rst
@@ -6,6 +6,7 @@ virtual images for Linux Kernel-based Virtual Machines. It supports the
 installation of `virtio kernel
 modules <http://www.linux-kvm.org/page/Virtio>`__ (paravirtualized
 drivers for IO operations).
+It also supports creating an image with LVM as a disk backend.
 
 Manifest settings
 -----------------
@@ -15,6 +16,9 @@ Provider
 
 -  ``virtio``: Specifies which virtio kernel modules to install.
    ``optional``
+-  ``logicalvolume``: Specifies the logical volume where the disk image will be built.
+   ``volumegroup``: Specifies the volume group where the logical volume will be stored.
+   These options should only be used if ``lvm`` was given as a disk backend.
 
 Example:
 
@@ -26,3 +30,7 @@ Example:
       virtio:
         - virtio_blk
         - virtio_net
+    volume:
+      backing: lvm
+      logicalvolume: lvtest
+      volumegroup: vgtest

--- a/bootstrapvz/providers/kvm/manifest-schema.yml
+++ b/bootstrapvz/providers/kvm/manifest-schema.yml
@@ -32,7 +32,11 @@ properties:
     properties:
       backing:
         type: string
-        enum: [raw]
+        enum: 
+        - raw
+        - lvm
+      logicalvolume: {type: string}
+      volumegroup: {type: string}
       partitions:
         type: object
         properties:

--- a/manifests/examples/kvm/jessie-lvm.yml
+++ b/manifests/examples/kvm/jessie-lvm.yml
@@ -1,0 +1,26 @@
+---
+name: debian-lvm-example
+provider:
+  name: kvm
+bootstrapper:
+  workspace: /target
+system:
+  release: jessie
+  architecture: amd64
+  bootloader: grub
+  charmap: UTF-8
+  locale: en_US
+  timezone: UTC
+volume:
+  backing: lvm
+  logicalvolume: lvtest
+  volumegroup: vgtest
+  partitions:
+    type: gpt
+    root:
+      filesystem: ext4
+      size: 1GB
+packages: {}
+plugins:
+  root_password:
+    password: test


### PR DESCRIPTION
Enables the use of Logical Volumes as a disk backing.

This was needed as we wanted to handle our images through LVM.
It will not create the logical volume group as reversing this could imply destroying pre-existing logical volumes.
Also to avoid overwriting volumes the bootstrapping process will fail if the logical volume already exists.

This update mirrors the functioning of the creation of an image on a loop device, except the target is a logical volume.
I have added an example manifest to test it out.