### PR TITLE
 Add /sbin and /usr/sbin to PATH if not present for archlinux compatibility

### DIFF
--- a/bootstrapvz/base/main.py
+++ b/bootstrapvz/base/main.py
@@ -22,6 +22,10 @@ def main():
     from manifest import Manifest
     manifest = Manifest(path=opts['MANIFEST'])
 
+    # Set-up Architecture independent path
+    if "usr/sbin" not in os.environ["PATH"]:
+        os.environ["PATH"] += os.pathsep + os.pathsep.join(["/usr/sbin", "/sbin", "/bin"])
+
     # Everything has been set up, begin the bootstrapping process
     run(manifest,
         debug=opts['--debug'],

--- a/bootstrapvz/base/main.py
+++ b/bootstrapvz/base/main.py
@@ -22,10 +22,6 @@ def main():
     from manifest import Manifest
     manifest = Manifest(path=opts['MANIFEST'])
 
-    # Set-up Architecture independent path
-    if "usr/sbin" not in os.environ["PATH"]:
-        os.environ["PATH"] += os.pathsep + os.pathsep.join(["/usr/sbin", "/sbin", "/bin"])
-
     # Everything has been set up, begin the bootstrapping process
     run(manifest,
         debug=opts['--debug'],

--- a/bootstrapvz/common/tasks/apt.py
+++ b/bootstrapvz/common/tasks/apt.py
@@ -1,6 +1,6 @@
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
-from bootstrapvz.common.tools import log_check_call
+from bootstrapvz.common.tools import log_check_call_chroot
 import locale
 import logging
 import os
@@ -193,8 +193,8 @@ class AptUpdate(Task):
 
     @classmethod
     def run(cls, info):
-        log_check_call(['chroot', info.root,
-                        'apt-get', 'update'])
+        log_check_call_chroot(['chroot', info.root,
+                               'apt-get', 'update'])
 
 
 class AptUpgrade(Task):
@@ -206,15 +206,15 @@ class AptUpgrade(Task):
     def run(cls, info):
         from subprocess import CalledProcessError
         try:
-            log_check_call(['chroot', info.root,
-                            'apt-get', 'install',
-                                       '--fix-broken',
-                                       '--no-install-recommends',
-                                       '--assume-yes'])
-            log_check_call(['chroot', info.root,
-                            'apt-get', 'upgrade',
-                                       '--no-install-recommends',
-                                       '--assume-yes'])
+            log_check_call_chroot(['chroot', info.root,
+                                   'apt-get', 'install',
+                                              '--fix-broken',
+                                              '--no-install-recommends',
+                                              '--assume-yes'])
+            log_check_call_chroot(['chroot', info.root,
+                                   'apt-get', 'upgrade',
+                                              '--no-install-recommends',
+                                              '--assume-yes'])
         except CalledProcessError as e:
             if e.returncode == 100:
                 msg = ('apt exited with status code 100. '
@@ -230,10 +230,10 @@ class PurgeUnusedPackages(Task):
 
     @classmethod
     def run(cls, info):
-        log_check_call(['chroot', info.root,
-                        'apt-get', 'autoremove',
-                                   '--purge',
-                                   '--assume-yes'])
+        log_check_call_chroot(['chroot', info.root,
+                               'apt-get', 'autoremove',
+                                          '--purge',
+                                          '--assume-yes'])
 
 
 class AptClean(Task):
@@ -242,8 +242,8 @@ class AptClean(Task):
 
     @classmethod
     def run(cls, info):
-        log_check_call(['chroot', info.root,
-                        'apt-get', 'clean'])
+        log_check_call_chroot(['chroot', info.root,
+                               'apt-get', 'clean'])
 
         lists = os.path.join(info.root, 'var/lib/apt/lists')
         for list_file in [os.path.join(lists, f) for f in os.listdir(lists)]:

--- a/bootstrapvz/common/tasks/boot.py
+++ b/bootstrapvz/common/tasks/boot.py
@@ -10,8 +10,8 @@ class UpdateInitramfs(Task):
 
     @classmethod
     def run(cls, info):
-        from ..tools import log_check_call
-        log_check_call(['chroot', info.root, 'update-initramfs', '-u'])
+        from ..tools import log_check_call_chroot
+        log_check_call_chroot(['chroot', info.root, 'update-initramfs', '-u'])
 
 
 class BlackListModules(Task):

--- a/bootstrapvz/common/tasks/extlinux.py
+++ b/bootstrapvz/common/tasks/extlinux.py
@@ -1,6 +1,6 @@
 from bootstrapvz.base import Task
 from .. import phases
-from ..tools import log_check_call
+from ..tools import log_check_call_chroot
 import filesystem
 import kernel
 from bootstrapvz.base.fs import partitionmaps
@@ -28,8 +28,8 @@ class ConfigureExtlinux(Task):
         from bootstrapvz.common.releases import squeeze
         if info.manifest.release == squeeze:
             # On squeeze /etc/default/extlinux is generated when running extlinux-update
-            log_check_call(['chroot', info.root,
-                            'extlinux-update'])
+            log_check_call_chroot(['chroot', info.root,
+                                   'extlinux-update'])
         from bootstrapvz.common.tools import sed_i
         extlinux_def = os.path.join(info.root, 'etc/default/extlinux')
         sed_i(extlinux_def, r'^EXTLINUX_PARAMETERS="([^"]+)"$',
@@ -47,15 +47,15 @@ class InstallExtlinux(Task):
             bootloader = '/usr/lib/syslinux/gptmbr.bin'
         else:
             bootloader = '/usr/lib/extlinux/mbr.bin'
-        log_check_call(['chroot', info.root,
-                        'dd', 'bs=440', 'count=1',
-                        'if=' + bootloader,
-                        'of=' + info.volume.device_path])
-        log_check_call(['chroot', info.root,
-                        'extlinux',
-                        '--install', '/boot/extlinux'])
-        log_check_call(['chroot', info.root,
-                        'extlinux-update'])
+        log_check_call_chroot(['chroot', info.root,
+                               'dd', 'bs=440', 'count=1',
+                               'if=' + bootloader,
+                               'of=' + info.volume.device_path])
+        log_check_call_chroot(['chroot', info.root,
+                               'extlinux',
+                               '--install', '/boot/extlinux'])
+        log_check_call_chroot(['chroot', info.root,
+                               'extlinux-update'])
 
 
 class ConfigureExtlinuxJessie(Task):
@@ -105,10 +105,10 @@ class InstallExtlinuxJessie(Task):
             bootloader = '/usr/lib/EXTLINUX/gptmbr.bin'
         else:
             bootloader = '/usr/lib/EXTLINUX/mbr.bin'
-        log_check_call(['chroot', info.root,
-                        'dd', 'bs=440', 'count=1',
-                        'if=' + bootloader,
-                        'of=' + info.volume.device_path])
-        log_check_call(['chroot', info.root,
-                        'extlinux',
-                        '--install', '/boot/extlinux'])
+        log_check_call_chroot(['chroot', info.root,
+                               'dd', 'bs=440', 'count=1',
+                               'if=' + bootloader,
+                               'of=' + info.volume.device_path])
+        log_check_call_chroot(['chroot', info.root,
+                               'extlinux',
+                               '--install', '/boot/extlinux'])

--- a/bootstrapvz/common/tasks/grub.py
+++ b/bootstrapvz/common/tasks/grub.py
@@ -1,7 +1,7 @@
 from bootstrapvz.base import Task
 from ..exceptions import TaskError
 from .. import phases
-from ..tools import log_check_call
+from ..tools import log_check_call_chroot, log_check_call
 import filesystem
 import kernel
 from bootstrapvz.base.fs import partitionmaps
@@ -317,8 +317,8 @@ class InstallGrub_1_99(Task):
                                                  idx=idx + 1))
 
             # Install grub
-            log_check_call(['chroot', info.root, 'grub-install', device_path])
-            log_check_call(['chroot', info.root, 'update-grub'])
+            log_check_call_chroot(['chroot', info.root, 'grub-install', device_path])
+            log_check_call_chroot(['chroot', info.root, 'update-grub'])
         finally:
             with unmounted(info.volume):
                 info.volume.unlink_dm_node()
@@ -335,5 +335,5 @@ class InstallGrub_2(Task):
 
     @classmethod
     def run(cls, info):
-        log_check_call(['chroot', info.root, 'grub-install', info.volume.device_path])
-        log_check_call(['chroot', info.root, 'update-grub'])
+        log_check_call_chroot(['chroot', info.root, 'grub-install', info.volume.device_path])
+        log_check_call_chroot(['chroot', info.root, 'update-grub'])

--- a/bootstrapvz/common/tasks/initd.py
+++ b/bootstrapvz/common/tasks/initd.py
@@ -1,6 +1,6 @@
 from bootstrapvz.base import Task
 from .. import phases
-from ..tools import log_check_call
+from ..tools import log_check_call_chroot
 from . import assets
 import os.path
 
@@ -22,15 +22,15 @@ class InstallInitScripts(Task):
             copy(src, dst)
             os.chmod(dst, rwxr_xr_x)
             if info.manifest.release > jessie:
-                log_check_call(['chroot', info.root, 'systemctl', 'enable', name])
+                log_check_call_chroot(['chroot', info.root, 'systemctl', 'enable', name])
             else:
-                log_check_call(['chroot', info.root, 'insserv', '--default', name])
+                log_check_call_chroot(['chroot', info.root, 'insserv', '--default', name])
 
         for name in info.initd['disable']:
             if info.manifest.release > jessie:
-                log_check_call(['chroot', info.root, 'systemctl', 'mask', name])
+                log_check_call_chroot(['chroot', info.root, 'systemctl', 'mask', name])
             else:
-                log_check_call(['chroot', info.root, 'insserv', '--remove', name])
+                log_check_call_chroot(['chroot', info.root, 'insserv', '--remove', name])
 
 
 class AddExpandRoot(Task):

--- a/bootstrapvz/common/tasks/kernel.py
+++ b/bootstrapvz/common/tasks/kernel.py
@@ -22,9 +22,9 @@ class UpdateInitramfs(Task):
 
     @classmethod
     def run(cls, info):
-        from bootstrapvz.common.tools import log_check_call
+        from bootstrapvz.common.tools import log_check_call_chroot
         # Update initramfs (-u) for all currently installed kernel versions (-k all)
-        log_check_call(['chroot', info.root, 'update-initramfs', '-u', '-k', 'all'])
+        log_check_call_chroot(['chroot', info.root, 'update-initramfs', '-u', '-k', 'all'])
 
 
 class DetermineKernelVersion(Task):

--- a/bootstrapvz/common/tasks/locale.py
+++ b/bootstrapvz/common/tasks/locale.py
@@ -21,7 +21,7 @@ class GenerateLocale(Task):
     @classmethod
     def run(cls, info):
         from ..tools import sed_i
-        from ..tools import log_check_call
+        from ..tools import log_check_call_chroot
 
         lang = '{locale}.{charmap}'.format(locale=info.manifest.system['locale'],
                                            charmap=info.manifest.system['charmap'])
@@ -32,9 +32,9 @@ class GenerateLocale(Task):
         locale_gen = os.path.join(info.root, 'etc/locale.gen')
         sed_i(locale_gen, search, locale_str)
 
-        log_check_call(['chroot', info.root, 'locale-gen'])
-        log_check_call(['chroot', info.root,
-                        'update-locale', 'LANG=' + lang])
+        log_check_call_chroot(['chroot', info.root, 'locale-gen'])
+        log_check_call_chroot(['chroot', info.root,
+                               'update-locale', 'LANG=' + lang])
 
 
 class SetTimezone(Task):

--- a/bootstrapvz/common/tasks/packages.py
+++ b/bootstrapvz/common/tasks/packages.py
@@ -1,7 +1,7 @@
 from bootstrapvz.base import Task
 from .. import phases
 import apt
-from ..tools import log_check_call
+from ..tools import log_check_call_chroot
 
 
 class AddManifestPackages(Task):
@@ -41,17 +41,16 @@ class InstallPackages(Task):
     @classmethod
     def install_remote(cls, info, remote_packages):
         import os
-        from ..tools import log_check_call
         from subprocess import CalledProcessError
         try:
             env = os.environ.copy()
             env['DEBIAN_FRONTEND'] = 'noninteractive'
-            log_check_call(['chroot', info.root,
-                            'apt-get', 'install',
-                                       '--no-install-recommends',
-                                       '--assume-yes'] +
-                           map(str, remote_packages),
-                           env=env)
+            log_check_call_chroot(['chroot', info.root,
+                                   'apt-get', 'install',
+                                              '--no-install-recommends',
+                                              '--assume-yes'] +
+                                  map(str, remote_packages),
+                                  env=env)
         except CalledProcessError as e:
             import logging
             disk_stat = os.statvfs(info.root)
@@ -90,9 +89,9 @@ class InstallPackages(Task):
 
         env = os.environ.copy()
         env['DEBIAN_FRONTEND'] = 'noninteractive'
-        log_check_call(['chroot', info.root,
-                        'dpkg', '--install'] + chrooted_package_paths,
-                       env=env)
+        log_check_call_chroot(['chroot', info.root,
+                               'dpkg', '--install'] + chrooted_package_paths,
+                              env=env)
 
         for path in absolute_package_paths:
             os.remove(path)
@@ -106,6 +105,6 @@ class AddTaskselStandardPackages(Task):
 
     @classmethod
     def run(cls, info):
-        tasksel_packages = log_check_call(['chroot', info.root, 'tasksel', '--task-packages', 'standard'])
+        tasksel_packages = log_check_call_chroot(['chroot', info.root, 'tasksel', '--task-packages', 'standard'])
         for pkg in tasksel_packages:
             info.packages.add(pkg)

--- a/bootstrapvz/common/tasks/security.py
+++ b/bootstrapvz/common/tasks/security.py
@@ -8,5 +8,5 @@ class EnableShadowConfig(Task):
 
     @classmethod
     def run(cls, info):
-        from ..tools import log_check_call
-        log_check_call(['chroot', info.root, 'shadowconfig', 'on'])
+        from ..tools import log_check_call_chroot
+        log_check_call_chroot(['chroot', info.root, 'shadowconfig', 'on'])

--- a/bootstrapvz/common/tasks/ssh.py
+++ b/bootstrapvz/common/tasks/ssh.py
@@ -1,6 +1,6 @@
 from bootstrapvz.base import Task
 from .. import phases
-from ..tools import log_check_call
+from ..tools import log_check_call_chroot
 import os.path
 from . import assets
 import initd
@@ -26,8 +26,8 @@ class AddSSHKeyGeneration(Task):
         install = info.initd['install']
         from subprocess import CalledProcessError
         try:
-            log_check_call(['chroot', info.root,
-                            'dpkg-query', '-W', 'openssh-server'])
+            log_check_call_chroot(['chroot', info.root,
+                                   'dpkg-query', '-W', 'openssh-server'])
             from bootstrapvz.common.releases import squeeze
             if info.manifest.release == squeeze:
                 install['generate-ssh-hostkeys'] = os.path.join(init_scripts_dir, 'squeeze/generate-ssh-hostkeys')

--- a/bootstrapvz/common/tools.py
+++ b/bootstrapvz/common/tools.py
@@ -20,6 +20,12 @@ def log_call(command, stdin=None, env=None, shell=False, cwd=None):
     from multiprocessing.dummy import Pool as ThreadPool
     from os.path import realpath
 
+    # Update PATH if command is chroot
+    if command[0] == 'chroot':
+        if "usr/sbin" not in os.environ["PATH"]:
+            if env is None or env is os.environ:
+                env = os.environ.copy()
+            env['PATH'] += os.pathsep + os.pathsep.join(["/usr/sbin", "/sbin", "/bin"])
     command_log = realpath(command[0]).replace('/', '.')
     log = logging.getLogger(__name__ + command_log)
     if type(command) is list:

--- a/bootstrapvz/common/tools.py
+++ b/bootstrapvz/common/tools.py
@@ -1,6 +1,25 @@
 import os
 
 
+def append_default_debian_path(env=None):
+    if "usr/sbin" not in os.environ["PATH"]:
+        if env is None or env is os.environ:
+            env = os.environ.copy()
+        env['PATH'] += os.pathsep + os.pathsep.join(["/usr/local/sbin", "/usr/local/bin",
+                                                     "/usr/sbin", "/usr/bin", "/sbin", "/bin"])
+        return env
+
+
+def log_check_call_chroot(command, stdin=None, env=None, shell=False, cwd=None):
+    env = append_default_debian_path(env)
+    log_check_call(command, stdin, env, shell, cwd)
+
+
+def log_call_chroot(command, stdin=None, env=None, shell=False, cwd=None):
+    env = append_default_debian_path(env)
+    log_call(command, stdin, env, shell, cwd)
+
+
 def log_check_call(command, stdin=None, env=None, shell=False, cwd=None):
     status, stdout, stderr = log_call(command, stdin, env, shell, cwd)
     from subprocess import CalledProcessError
@@ -20,12 +39,6 @@ def log_call(command, stdin=None, env=None, shell=False, cwd=None):
     from multiprocessing.dummy import Pool as ThreadPool
     from os.path import realpath
 
-    # Update PATH if command is chroot
-    if command[0] == 'chroot':
-        if "usr/sbin" not in os.environ["PATH"]:
-            if env is None or env is os.environ:
-                env = os.environ.copy()
-            env['PATH'] += os.pathsep + os.pathsep.join(["/usr/sbin", "/sbin", "/bin"])
     command_log = realpath(command[0]).replace('/', '.')
     log = logging.getLogger(__name__ + command_log)
     if type(command) is list:

--- a/bootstrapvz/plugins/admin_user/tasks.py
+++ b/bootstrapvz/plugins/admin_user/tasks.py
@@ -44,11 +44,11 @@ class CreateAdminUser(Task):
 
     @classmethod
     def run(cls, info):
-        from bootstrapvz.common.tools import log_check_call
-        log_check_call(['chroot', info.root,
-                        'useradd',
-                        '--create-home', '--shell', '/bin/bash',
-                        info.manifest.plugins['admin_user']['username']])
+        from bootstrapvz.common.tools import log_check_call_chroot
+        log_check_call_chroot(['chroot', info.root,
+                               'useradd',
+                               '--create-home', '--shell', '/bin/bash',
+                               info.manifest.plugins['admin_user']['username']])
 
 
 class PasswordlessSudo(Task):
@@ -73,10 +73,10 @@ class AdminUserPassword(Task):
 
     @classmethod
     def run(cls, info):
-        from bootstrapvz.common.tools import log_check_call
-        log_check_call(['chroot', info.root, 'chpasswd'],
-                       info.manifest.plugins['admin_user']['username'] +
-                       ':' + info.manifest.plugins['admin_user']['password'])
+        from bootstrapvz.common.tools import log_check_call_chroot
+        log_check_call_chroot(['chroot', info.root, 'chpasswd'],
+                              info.manifest.plugins['admin_user']['username'] +
+                              ':' + info.manifest.plugins['admin_user']['password'])
 
 
 class AdminUserPublicKey(Task):
@@ -122,9 +122,9 @@ class AdminUserPublicKey(Task):
 
         # Set the owner of the authorized keys file
         # (must be through chroot, the host system doesn't know about the user)
-        from bootstrapvz.common.tools import log_check_call
-        log_check_call(['chroot', info.root,
-                        'chown', '-R', (username + ':' + username), ssh_dir_rel])
+        from bootstrapvz.common.tools import log_check_call_chroot
+        log_check_call_chroot(['chroot', info.root,
+                               'chown', '-R', (username + ':' + username), ssh_dir_rel])
 
 
 class AdminUserPublicKeyEC2(Task):

--- a/bootstrapvz/plugins/ansible/tasks.py
+++ b/bootstrapvz/plugins/ansible/tasks.py
@@ -34,7 +34,7 @@ class RunAnsiblePlaybook(Task):
 
     @classmethod
     def run(cls, info):
-        from bootstrapvz.common.tools import log_check_call
+        from bootstrapvz.common.tools import log_check_call_chroot
 
         # Extract playbook and directory
         playbook = info.manifest.plugins['ansible']['playbook']
@@ -92,5 +92,5 @@ class RunAnsiblePlaybook(Task):
             cmd.extend(opt_flags)
 
         # Run and remove the inventory file
-        log_check_call(cmd, cwd=playbook_dir)
+        log_check_call_chroot(cmd, cwd=playbook_dir)
         os.remove(inventory)

--- a/bootstrapvz/plugins/cloud_init/tasks.py
+++ b/bootstrapvz/plugins/cloud_init/tasks.py
@@ -1,6 +1,6 @@
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
-from bootstrapvz.common.tools import log_check_call
+from bootstrapvz.common.tools import log_check_call_chroot
 from bootstrapvz.common.tasks import apt
 from bootstrapvz.common.tasks import locale
 import logging
@@ -73,7 +73,7 @@ class SetMetadataSource(Task):
                 logging.getLogger(__name__).warn(msg)
                 return
         sources = "cloud-init    cloud-init/datasources    multiselect    " + sources
-        log_check_call(['chroot', info.root, 'debconf-set-selections'], sources)
+        log_check_call_chroot(['chroot', info.root, 'debconf-set-selections'], sources)
 
 
 class DisableModules(Task):

--- a/bootstrapvz/plugins/commands/tasks.py
+++ b/bootstrapvz/plugins/commands/tasks.py
@@ -8,8 +8,8 @@ class ImageExecuteCommand(Task):
 
     @classmethod
     def run(cls, info):
-        from bootstrapvz.common.tools import log_check_call
+        from bootstrapvz.common.tools import log_check_call_chroot
         for raw_command in info.manifest.plugins['commands']['commands']:
             command = map(lambda part: part.format(root=info.root, **info.manifest_vars), raw_command)
             shell = len(command) == 1
-            log_check_call(command, shell=shell)
+            log_check_call_chroot(command, shell=shell)

--- a/bootstrapvz/plugins/debconf/tasks.py
+++ b/bootstrapvz/plugins/debconf/tasks.py
@@ -1,7 +1,7 @@
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
 from bootstrapvz.common.tasks import packages
-from bootstrapvz.common.tools import log_check_call
+from bootstrapvz.common.tools import log_check_call_chroot
 
 
 class DebconfSetSelections(Task):
@@ -11,5 +11,5 @@ class DebconfSetSelections(Task):
 
     @classmethod
     def run(cls, info):
-        log_check_call(['chroot', info.root, 'debconf-set-selections'],
-                       stdin=info.manifest.plugins['debconf'])
+        log_check_call_chroot(['chroot', info.root, 'debconf-set-selections'],
+                              stdin=info.manifest.plugins['debconf'])

--- a/bootstrapvz/plugins/expand_root/tasks.py
+++ b/bootstrapvz/plugins/expand_root/tasks.py
@@ -2,7 +2,7 @@ from bootstrapvz.base import Task
 from bootstrapvz.common import phases
 from bootstrapvz.common.tasks import initd
 from bootstrapvz.common.tasks import packages
-from bootstrapvz.common.tools import log_check_call
+from bootstrapvz.common.tools import log_check_call_chroot
 from bootstrapvz.common.tools import rel_path
 from bootstrapvz.common.tools import sed_i
 import os
@@ -55,4 +55,4 @@ class InstallExpandRootScripts(Task):
               'ExecStart=/usr/bin/expand-root.sh %s' % opts)
 
         # Enable systemd service
-        log_check_call(['chroot', info.root,  'systemctl', 'enable', 'expand-root.service'])
+        log_check_call_chroot(['chroot', info.root,  'systemctl', 'enable', 'expand-root.service'])

--- a/bootstrapvz/plugins/file_copy/tasks.py
+++ b/bootstrapvz/plugins/file_copy/tasks.py
@@ -6,20 +6,20 @@ import shutil
 
 
 def modify_path(info, path, entry):
-    from bootstrapvz.common.tools import log_check_call
+    from bootstrapvz.common.tools import log_check_call_chroot
     if 'permissions' in entry:
         # We wrap the permissions string in str() in case
         #  the user specified a numeric bitmask
         chmod_command = ['chroot', info.root, 'chmod', str(entry['permissions']), path]
-        log_check_call(chmod_command)
+        log_check_call_chroot(chmod_command)
 
     if 'owner' in entry:
         chown_command = ['chroot', info.root, 'chown', entry['owner'], path]
-        log_check_call(chown_command)
+        log_check_call_chroot(chown_command)
 
     if 'group' in entry:
         chgrp_command = ['chroot', info.root, 'chgrp', entry['group'], path]
-        log_check_call(chgrp_command)
+        log_check_call_chroot(chgrp_command)
 
 
 class MkdirCommand(Task):
@@ -28,11 +28,11 @@ class MkdirCommand(Task):
 
     @classmethod
     def run(cls, info):
-        from bootstrapvz.common.tools import log_check_call
+        from bootstrapvz.common.tools import log_check_call_chroot
 
         for dir_entry in info.manifest.plugins['file_copy']['mkdirs']:
             mkdir_command = ['chroot', info.root, 'mkdir', '-p', dir_entry['dir']]
-            log_check_call(mkdir_command)
+            log_check_call_chroot(mkdir_command)
             modify_path(info, dir_entry['dir'], dir_entry)
 
 

--- a/bootstrapvz/plugins/google_cloud_repo/tasks.py
+++ b/bootstrapvz/plugins/google_cloud_repo/tasks.py
@@ -2,7 +2,7 @@ from bootstrapvz.base import Task
 from bootstrapvz.common import phases
 from bootstrapvz.common.tasks import apt
 from bootstrapvz.common.tasks import packages
-from bootstrapvz.common.tools import log_check_call
+from bootstrapvz.common.tools import log_check_call, log_check_call_chroot
 import os
 
 
@@ -16,7 +16,7 @@ class AddGoogleCloudRepoKey(Task):
     def run(cls, info):
         key_file = os.path.join(info.root, 'google.gpg.key')
         log_check_call(['wget', 'https://packages.cloud.google.com/apt/doc/apt-key.gpg', '-O', key_file])
-        log_check_call(['chroot', info.root, 'apt-key', 'add', 'google.gpg.key'])
+        log_check_call_chroot(['chroot', info.root, 'apt-key', 'add', 'google.gpg.key'])
         os.remove(key_file)
 
 

--- a/bootstrapvz/plugins/pip_install/tasks.py
+++ b/bootstrapvz/plugins/pip_install/tasks.py
@@ -18,8 +18,8 @@ class PipInstallCommand(Task):
 
     @classmethod
     def run(cls, info):
-        from bootstrapvz.common.tools import log_check_call
+        from bootstrapvz.common.tools import log_check_call_chroot
         packages = info.manifest.plugins['pip_install']['packages']
         pip_install_command = ['chroot', info.root, 'pip', 'install']
         pip_install_command.extend(packages)
-        log_check_call(pip_install_command)
+        log_check_call_chroot(pip_install_command)

--- a/bootstrapvz/plugins/puppet/tasks.py
+++ b/bootstrapvz/plugins/puppet/tasks.py
@@ -73,9 +73,9 @@ class ApplyPuppetManifest(Task):
         copy(pp_manifest, manifest_dst)
 
         manifest_path = os.path.join('/', manifest_rel_dst)
-        from bootstrapvz.common.tools import log_check_call
-        log_check_call(['chroot', info.root,
-                        'puppet', 'apply', manifest_path])
+        from bootstrapvz.common.tools import log_check_call_chroot
+        log_check_call_chroot(['chroot', info.root,
+                               'puppet', 'apply', manifest_path])
         os.remove(manifest_dst)
 
         hosts_path = os.path.join(info.root, 'etc/hosts')

--- a/bootstrapvz/plugins/root_password/tasks.py
+++ b/bootstrapvz/plugins/root_password/tasks.py
@@ -8,6 +8,6 @@ class SetRootPassword(Task):
 
     @classmethod
     def run(cls, info):
-        from bootstrapvz.common.tools import log_check_call
-        log_check_call(['chroot', info.root, 'chpasswd'],
-                       'root:' + info.manifest.plugins['root_password']['password'])
+        from bootstrapvz.common.tools import log_check_call_chroot
+        log_check_call_chroot(['chroot', info.root, 'chpasswd'],
+                              'root:' + info.manifest.plugins['root_password']['password'])

--- a/bootstrapvz/plugins/salt/tasks.py
+++ b/bootstrapvz/plugins/salt/tasks.py
@@ -1,7 +1,7 @@
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
 from bootstrapvz.common.tasks import packages
-from bootstrapvz.common.tools import log_check_call
+from bootstrapvz.common.tools import log_check_call_chroot
 from bootstrapvz.common.tools import sed_i
 import os
 import urllib
@@ -44,7 +44,7 @@ class BootstrapSaltMinion(Task):
         bootstrap_command.append(install_source)
         if install_source == 'git' and ('version' in info.manifest.plugins['salt']):
             bootstrap_command.append(info.manifest.plugins['salt']['version'])
-        log_check_call(bootstrap_command)
+        log_check_call_chroot(bootstrap_command)
 
 
 class SetSaltGrains(Task):

--- a/bootstrapvz/plugins/vagrant/tasks.py
+++ b/bootstrapvz/plugins/vagrant/tasks.py
@@ -53,11 +53,11 @@ class CreateVagrantUser(Task):
 
     @classmethod
     def run(cls, info):
-        from bootstrapvz.common.tools import log_check_call
-        log_check_call(['chroot', info.root,
-                        'useradd',
-                        '--create-home', '--shell', '/bin/bash',
-                        'vagrant'])
+        from bootstrapvz.common.tools import log_check_call_chroot
+        log_check_call_chroot(['chroot', info.root,
+                               'useradd',
+                               '--create-home', '--shell', '/bin/bash',
+                               'vagrant'])
 
 
 class PasswordlessSudo(Task):
@@ -97,10 +97,10 @@ class AddInsecurePublicKey(Task):
         os.chmod(authorized_keys_path, stat.S_IRUSR | stat.S_IWUSR)
 
         # We can't do this directly with python, since getpwnam gets its info from the host
-        from bootstrapvz.common.tools import log_check_call
-        log_check_call(['chroot', info.root,
-                        'chown', 'vagrant:vagrant',
-                        '/home/vagrant/.ssh', '/home/vagrant/.ssh/authorized_keys'])
+        from bootstrapvz.common.tools import log_check_call_chroot
+        log_check_call_chroot(['chroot', info.root,
+                               'chown', 'vagrant:vagrant',
+                               '/home/vagrant/.ssh', '/home/vagrant/.ssh/authorized_keys'])
 
 
 class SetRootPassword(Task):
@@ -109,8 +109,8 @@ class SetRootPassword(Task):
 
     @classmethod
     def run(cls, info):
-        from bootstrapvz.common.tools import log_check_call
-        log_check_call(['chroot', info.root, 'chpasswd'], 'root:vagrant')
+        from bootstrapvz.common.tools import log_check_call_chroot
+        log_check_call_chroot(['chroot', info.root, 'chpasswd'], 'root:vagrant')
 
 
 class PackageBox(Task):

--- a/bootstrapvz/providers/azure/tasks/packages.py
+++ b/bootstrapvz/providers/azure/tasks/packages.py
@@ -29,7 +29,7 @@ class Waagent(Task):
 
     @classmethod
     def run(cls, info):
-        from bootstrapvz.common.tools import log_check_call
+        from bootstrapvz.common.tools import log_check_call, log_check_call_chroot
         import os
         waagent_version = info.manifest.provider['waagent']['version']
         waagent_file = 'WALinuxAgent-' + waagent_version + '.tar.gz'
@@ -39,9 +39,9 @@ class Waagent(Task):
         log_check_call(['tar', 'xaf', os.path.join(info.root, waagent_file), '-C', waagent_directory])
         os.remove(os.path.join(info.root, waagent_file))
         waagent_script = '/root/WALinuxAgent-WALinuxAgent-' + waagent_version + '/waagent'
-        log_check_call(['chroot', info.root, 'cp', waagent_script, '/usr/sbin/waagent'])
-        log_check_call(['chroot', info.root, 'chmod', '755', '/usr/sbin/waagent'])
-        log_check_call(['chroot', info.root, 'waagent', '-install'])
+        log_check_call_chroot(['chroot', info.root, 'cp', waagent_script, '/usr/sbin/waagent'])
+        log_check_call_chroot(['chroot', info.root, 'chmod', '755', '/usr/sbin/waagent'])
+        log_check_call_chroot(['chroot', info.root, 'waagent', '-install'])
         if info.manifest.provider['waagent'].get('conf', False):
             if os.path.isfile(info.manifest.provider['waagent']['conf']):
                 log_check_call(['cp', info.manifest.provider['waagent']['conf'],

--- a/bootstrapvz/providers/ec2/tasks/boot.py
+++ b/bootstrapvz/providers/ec2/tasks/boot.py
@@ -3,7 +3,7 @@ from bootstrapvz.common import phases
 from bootstrapvz.common.tasks import grub
 from . import assets
 import os
-from bootstrapvz.common.tools import log_check_call
+from bootstrapvz.common.tools import log_check_call_chroot
 
 
 class AddXenGrubConsoleOutputDevice(Task):
@@ -23,7 +23,7 @@ class UpdateGrubConfig(Task):
 
     @classmethod
     def run(cls, info):
-        log_check_call(['chroot', info.root, 'update-grub'])
+        log_check_call_chroot(['chroot', info.root, 'update-grub'])
 
 
 class CreatePVGrubCustomRule(Task):
@@ -80,5 +80,4 @@ class LinkGrubConfig(Task):
 
     @classmethod
     def run(cls, info):
-        log_check_call(['chroot', info.root,
-                        'ln', '--symbolic', '/boot/grub/grub.cfg', '/boot/grub/menu.lst'])
+        log_check_call_chroot(['chroot', info.root, 'ln', '--symbolic', '/boot/grub/grub.cfg', '/boot/grub/menu.lst'])

--- a/bootstrapvz/providers/ec2/tasks/network.py
+++ b/bootstrapvz/providers/ec2/tasks/network.py
@@ -97,7 +97,7 @@ class InstallEnhancedNetworking(Task):
         import urllib
         urllib.urlretrieve(drivers_url, archive)
 
-        from bootstrapvz.common.tools import log_check_call
+        from bootstrapvz.common.tools import log_check_call, log_check_call_chroot
         log_check_call(['tar', '--ungzip',
                                '--extract',
                                '--file', archive,
@@ -118,9 +118,9 @@ AUTOINSTALL="yes"
 
         for task in ['add', 'build', 'install']:
             # Invoke DKMS task using specified kernel module (-m) and version (-v)
-            log_check_call(['chroot', info.root,
-                            'dkms', task, '-m', 'ixgbevf', '-v', version, '-k',
-                            info.kernel_version])
+            log_check_call_chroot(['chroot', info.root,
+                                   'dkms', task, '-m', 'ixgbevf', '-v', version, '-k',
+                                   info.kernel_version])
 
 
 class InstallENANetworking(Task):
@@ -135,7 +135,7 @@ class InstallENANetworking(Task):
         module_path = os.path.join(info.root, 'usr', 'src',
                                    'amzn-drivers-%s' % (version))
 
-        from bootstrapvz.common.tools import log_check_call
+        from bootstrapvz.common.tools import log_check_call, log_check_call_chroot
         log_check_call(['git', 'clone', drivers_url, module_path])
 
         with open(os.path.join(module_path, 'dkms.conf'), 'w') as dkms_conf:
@@ -152,6 +152,6 @@ AUTOINSTALL="yes"
 
         for task in ['add', 'build', 'install']:
             # Invoke DKMS task using specified kernel module (-m) and version (-v)
-            log_check_call(['chroot', info.root,
-                            'dkms', task, '-m', 'amzn-drivers', '-v', version,
-                            '-k', info.kernel_version])
+            log_check_call_chroot(['chroot', info.root,
+                                   'dkms', task, '-m', 'amzn-drivers', '-v', version,
+                                   '-k', info.kernel_version])

--- a/bootstrapvz/providers/gce/tasks/apt.py
+++ b/bootstrapvz/providers/gce/tasks/apt.py
@@ -2,7 +2,7 @@ from bootstrapvz.base import Task
 from bootstrapvz.common import phases
 from bootstrapvz.common.tasks import apt
 from bootstrapvz.common.tasks import network
-from bootstrapvz.common.tools import log_check_call
+from bootstrapvz.common.tools import log_check_call_chroot
 
 
 class AddBaselineAptCache(Task):
@@ -13,4 +13,4 @@ class AddBaselineAptCache(Task):
 
     @classmethod
     def run(cls, info):
-        log_check_call(['chroot', info.root, 'apt-get', 'update'])
+        log_check_call_chroot(['chroot', info.root, 'apt-get', 'update'])

--- a/bootstrapvz/providers/gce/tasks/configuration.py
+++ b/bootstrapvz/providers/gce/tasks/configuration.py
@@ -1,6 +1,6 @@
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
-from bootstrapvz.common.tools import log_check_call
+from bootstrapvz.common.tools import log_check_call_chroot
 
 
 class GatherReleaseInformation(Task):
@@ -9,9 +9,9 @@ class GatherReleaseInformation(Task):
 
     @classmethod
     def run(cls, info):
-        lsb_distribution = log_check_call(['chroot', info.root, 'lsb_release', '-i', '-s'])
-        lsb_description = log_check_call(['chroot', info.root, 'lsb_release', '-d', '-s'])
-        lsb_release = log_check_call(['chroot', info.root, 'lsb_release', '-r', '-s'])
+        lsb_distribution = log_check_call_chroot(['chroot', info.root, 'lsb_release', '-i', '-s'])
+        lsb_description = log_check_call_chroot(['chroot', info.root, 'lsb_release', '-d', '-s'])
+        lsb_release = log_check_call_chroot(['chroot', info.root, 'lsb_release', '-r', '-s'])
         info._gce['lsb_distribution'] = lsb_distribution[0]
         info._gce['lsb_description'] = lsb_description[0]
         info._gce['lsb_release'] = lsb_release[0]

--- a/bootstrapvz/providers/virtualbox/tasks/guest_additions.py
+++ b/bootstrapvz/providers/virtualbox/tasks/guest_additions.py
@@ -52,8 +52,8 @@ class InstallGuestAdditions(Task):
 
     @classmethod
     def run(cls, info):
-        from bootstrapvz.common.tools import log_call, log_check_call
-        for line in log_check_call(['chroot', info.root, 'apt-cache', 'show', info.kernel['headers_pkg']]):
+        from bootstrapvz.common.tools import log_check_call_chroot, log_call_chroot
+        for line in log_check_call_chroot(['chroot', info.root, 'apt-cache', 'show', info.kernel['headers_pkg']]):
             key, value = line.split(':')
             if key.strip() == 'Depends':
                 kernel_version = value.strip().split('linux-headers-')[-1]
@@ -77,10 +77,10 @@ class InstallGuestAdditions(Task):
             f.write(install_wrapper + '\n')
 
         # Don't check the return code of the scripts here, because 1 not necessarily means they have failed
-        log_call(['chroot', info.root, 'bash', '/' + install_wrapper_name])
+        log_call_chroot(['chroot', info.root, 'bash', '/' + install_wrapper_name])
 
         # VBoxService process could be running, as it is not affected by DisableDaemonAutostart
-        log_call(['chroot', info.root, 'service', 'vboxadd-service', 'stop'])
+        log_call_chroot(['chroot', info.root, 'service', 'vboxadd-service', 'stop'])
         root.remove_mount(mount_path)
         os.rmdir(mount_path)
         os.remove(install_wrapper_path)


### PR DESCRIPTION
Enables the use of bootstrap-vz on Archlinux and other platforms not having /sbin and /usr/sbin in their PATH.