### PR TITLE
Fix unfailing CheckExternalCommands

### DIFF
--- a/bootstrapvz/common/tasks/host.py
+++ b/bootstrapvz/common/tasks/host.py
@@ -9,14 +9,14 @@ class CheckExternalCommands(Task):
 
     @classmethod
     def run(cls, info):
-        from ..tools import log_check_call
-        from subprocess import CalledProcessError
         import re
+        import logging
+        from distutils.spawn import find_executable
         missing_packages = []
+        log = logging.getLogger(__name__)
         for command, package in info.host_dependencies.items():
-            try:
-                log_check_call(['type', command], shell=True)
-            except CalledProcessError:
+            log.debug('Checking availability of ' + command)
+            if find_executable(command) is None:
                 if re.match('^https?:\/\/', package):
                     msg = ('The command `{command}\' is not available, '
                            'you can download the software at `{package}\'.'

--- a/bootstrapvz/common/tasks/host.py
+++ b/bootstrapvz/common/tasks/host.py
@@ -10,13 +10,15 @@ class CheckExternalCommands(Task):
     @classmethod
     def run(cls, info):
         import re
+        import os
         import logging
         from distutils.spawn import find_executable
         missing_packages = []
         log = logging.getLogger(__name__)
         for command, package in info.host_dependencies.items():
             log.debug('Checking availability of ' + command)
-            if find_executable(command) is None:
+            path = find_executable(command)
+            if path is None or not os.access(path, os.X_OK):
                 if re.match('^https?:\/\/', package):
                     msg = ('The command `{command}\' is not available, '
                            'you can download the software at `{package}\'.'


### PR DESCRIPTION
As referred in [#380](https://github.com/andsens/bootstrap-vz/issues/380), the presence check of needed commands never fails.

When Popen is given `shell=True`, the shell defaults to /bin/sh.
Using `Popen(['type', command], shell=True)` is equivalent to calling
`Popen(['/bin/sh', '-c', 'type', command])`.
In this case 'command' becomes a positional parameter to the shell,
not an argument to the command 'type'.

Therefore a single string must be given as parameter.